### PR TITLE
fit numpy.random.zipf

### DIFF
--- a/plfit/plfit.py
+++ b/plfit/plfit.py
@@ -969,7 +969,7 @@ def discrete_alpha_mle(data, xmin):
     if nn < 2:
         return 0
     xx = data[gexmin]
-    alpha = 1.0 + float(nn) * ( sum(log(xx/(xmin-0.5))) )**-1
+    alpha = 1.0 + float(nn) * (sum(log(xx/(float(xmin)-0.5))))**-1
     return alpha
 
 def discrete_best_alpha(data, alpharangemults=(0.9,1.1), n_alpha=201, approximate=True, verbose=True):
@@ -1018,11 +1018,12 @@ def discrete_ksD(data, xmin, alpha):
     """
     zz = np.sort(data[data>=xmin])
     nn = float(len(zz))
-    if nn < 2: return np.inf
+    if nn < 2:
+        return np.inf
     #cx = np.arange(nn,dtype='float')/float(nn)
     #cf = 1.0-(zz/xmin)**(1.0-alpha)
-    model_cdf = 1.0-(zz/xmin)**(1.0-alpha)
-    data_cdf  = np.searchsorted(zz,zz,side='left')/(float(nn))
+    model_cdf = 1.0-(zz.astype('float')/float(xmin))**(1.0-alpha)
+    data_cdf = np.searchsorted(zz,zz,side='left')/(float(nn))
 
     ks = max(abs(model_cdf-data_cdf))
     return ks

--- a/plfit/tests/test_regression.py
+++ b/plfit/tests/test_regression.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from .. import plfit
+
+def test_issue6():
+    # Issue 6 turned out to be a bug in the python 2 discrete fitter related to
+    # types
+    np.random.seed(0)
+
+    test_results = [plfit(np.random.zipf(1.5,1000), discrete=True).plfit() for ii in range(20)]
+
+    correct_results = [(11, 1.446205203835651),
+                       (11, 1.5281527659073806),
+                       (24, 1.4781899809035757),
+                       (5, 1.4762448609017413),
+                       (6, 1.5172567915706954),
+                       (5, 1.4926118375988198),
+                       (7, 1.4633992733678034),
+                       (26, 1.4565068571094049),
+                       (11, 1.463556822667798),
+                       (5, 1.5208086553278282),
+                       (20, 1.4684626049662981),
+                       (9, 1.5119585501695973),
+                       (9, 1.503821313598722),
+                       (7, 1.5135408351009809),
+                       (27, 1.4630831170687351),
+                       (14, 1.5560600392125927),
+                       (15, 1.4989900244136263),
+                       (11, 1.4632893374088225),
+                       (5, 1.5203141202088135),
+                       (5, 1.5052229915552222)]
+    
+    for (xmin,alpha),(xmin_,alpha_) in zip(correct_results,test_results):
+        assert xmin == xmin_
+        np.testing.assert_almost_equal(alpha,alpha_)


### PR DESCRIPTION
In order to test the code I tried fitting a zipf generated using numpy as follows:

```
myfit = plfit.plfit(np.random.zipf(1.5, 1000), discrete=True)
test_fit = myfit.test_pl()
```

However the values obtained were:

```
alpha: 1.46 (reasonable)
xmin:709 ( extremeley weird )
p_value: 0 (wrong)
```

I am using python version 2.7.9 and numpy version 1.6.2



